### PR TITLE
transformation issues 

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jaitools</groupId>
         <artifactId>jaitools</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
     <artifactId>jt-demo</artifactId>
     <packaging>jar</packaging>

--- a/jt-all/pom.xml
+++ b/jt-all/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jaitools</artifactId>
         <groupId>org.jaitools</groupId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
     
     <artifactId>jt-all</artifactId>

--- a/operator/attributeop/pom.xml
+++ b/operator/attributeop/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>operator</artifactId>
         <groupId>org.jaitools</groupId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
   
     <artifactId>jt-attributeop</artifactId>

--- a/operator/classifiedstats/pom.xml
+++ b/operator/classifiedstats/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jaitools</groupId>
         <artifactId>operator</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
 
     <artifactId>jt-classifiedstats</artifactId>

--- a/operator/contour/pom.xml
+++ b/operator/contour/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jaitools</groupId>
         <artifactId>operator</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
   
     <artifactId>jt-contour</artifactId>

--- a/operator/generate/pom.xml
+++ b/operator/generate/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jaitools</groupId>
         <artifactId>operator</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
 
     <artifactId>jt-generate</artifactId>

--- a/operator/kernelstats/pom.xml
+++ b/operator/kernelstats/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jaitools</groupId>
         <artifactId>operator</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
     
     <artifactId>jt-kernelstats</artifactId>

--- a/operator/maskedconvolve/pom.xml
+++ b/operator/maskedconvolve/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jaitools</groupId>
         <artifactId>operator</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
 
     <artifactId>jt-maskedconvolve</artifactId>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jaitools</groupId>
         <artifactId>jaitools</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
 
     <artifactId>operator</artifactId>

--- a/operator/rangelookup/pom.xml
+++ b/operator/rangelookup/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jaitools</groupId>
         <artifactId>operator</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
 
     <artifactId>jt-rangelookup</artifactId>

--- a/operator/regionalize/pom.xml
+++ b/operator/regionalize/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jaitools</groupId>
         <artifactId>operator</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
 
     <artifactId>jt-regionalize</artifactId>

--- a/operator/vectorbinarize/pom.xml
+++ b/operator/vectorbinarize/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>operator</artifactId>
         <groupId>org.jaitools</groupId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
     <artifactId>jt-vectorbinarize</artifactId>
     <name>VectorBinarize operator</name>

--- a/operator/vectorize/pom.xml
+++ b/operator/vectorize/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>operator</artifactId>
         <groupId>org.jaitools</groupId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
   
     <artifactId>jt-vectorize</artifactId>

--- a/operator/zonalstats/pom.xml
+++ b/operator/zonalstats/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jaitools</groupId>
         <artifactId>operator</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
 
     <artifactId>jt-zonalstats</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.jaitools</groupId>
     <artifactId>jaitools</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.4</version>
 
     <packaging>pom</packaging>
     <name>JAITools</name>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jaitools</groupId>
         <artifactId>jaitools</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
 
     <artifactId>jt-utils</artifactId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -21,6 +21,11 @@
             <groupId>com.vividsolutions</groupId>
             <artifactId>jts</artifactId>
         </dependency>
+        <dependency>
+            <artifactId>junit</artifactId>
+            <groupId>junit</groupId>
+            <version>4.11</version>
+        </dependency>
     </dependencies>
 </project>
 

--- a/utils/src/main/java/org/jaitools/tilecache/BasicCacheVisitor.java
+++ b/utils/src/main/java/org/jaitools/tilecache/BasicCacheVisitor.java
@@ -29,7 +29,7 @@ import java.awt.image.RenderedImage;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -99,7 +99,7 @@ public class BasicCacheVisitor implements DiskMemTileCacheVisitor {
     }
 
     private List<DiskCachedTile> tiles = new ArrayList<DiskCachedTile>();
-    private Map<Key, Object> filters = new HashMap<Key, Object>();
+    private Map<Key, Object> filters = new LinkedHashMap<Key, Object>();
 
 
     /**

--- a/utils/src/main/java/org/jaitools/tiledimage/DiskMemImageGraphics.java
+++ b/utils/src/main/java/org/jaitools/tiledimage/DiskMemImageGraphics.java
@@ -1095,7 +1095,7 @@ public class DiskMemImageGraphics extends Graphics2D {
             gr.setRenderingHints(renderingHints);
         }
         gr.setStroke(stroke);
-        gr.setTransform(transform);
+        gr.setTransform(new AffineTransform(transform));
     }
 
     /**

--- a/utils/src/test/java/org/jaitools/tilecache/DiskCachedTileTest.java
+++ b/utils/src/test/java/org/jaitools/tilecache/DiskCachedTileTest.java
@@ -78,7 +78,7 @@ public class DiskCachedTileTest {
         
         File oldFolder = DiskCachedTile.getCacheFolder();
         
-        File newFolder = new File("/foo/bar");
+        File newFolder = new File(System.getProperty("java.io.tmpdir"));
         DiskCachedTile.setCacheFolder(newFolder);
 
         assertEquals(newFolder, DiskCachedTile.getCacheFolder());

--- a/utils/src/test/java/org/jaitools/tiledimage/ImageGraphicsGeneralTest.java
+++ b/utils/src/test/java/org/jaitools/tiledimage/ImageGraphicsGeneralTest.java
@@ -26,6 +26,7 @@ package org.jaitools.tiledimage;
 
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -111,5 +112,23 @@ public class ImageGraphicsGeneralTest extends TiledImageTestBase {
         
         gr.setFont(null);
         assertNotNull(gr.getFont());
+    }
+    
+    @Test
+    public void testTransformationCopyOnCreation() {        
+        //ensure base behaviour
+        assertNotNull(gr.getTransform());
+        assertEquals(1.0,gr.getTransform().getScaleX(), 0.0001);
+        gr.scale(2, 2);
+        assertEquals(2.0,gr.getTransform().getScaleX(), 0.0001);
+        assertTrue(gr instanceof DiskMemImageGraphics);
+        
+        Graphics2D subgr = (Graphics2D) gr.create();
+        assertEquals(2, subgr.getTransform().getScaleX(), 0.0001);
+        subgr.scale(3, 3);
+        assertEquals(6, subgr.getTransform().getScaleX(), 0.0001);
+        
+        //but the original transformation is not touched
+        assertEquals(2.0,gr.getTransform().getScaleX(), 0.0001);
     }
 }


### PR DESCRIPTION
This patch adresses some issues. 

Using DiskMemImageGraphics.create does not copy the used AffineTransformation but uses the original one. This has the effect that on using scale, rotate etc. the original transformation in the original Graphics2D object is changed as well. A test is included as well.

The TileCacheVisitorTest does fail if a new JDK is used on a fast computer. This is due to DiskMemTileCache.defaultMemoryControl line 807. The comparator does sort by TileAccessTimeComparator. The access time of all tiles could be equal on fast computers.

Assuming that the filter order within the BaseCacheVisitor should be preserved I changed the implementation to a LinkedHashMap.